### PR TITLE
 migration to the new npe2 format

### DIFF
--- a/napari_yapic_prediction/napari.yaml
+++ b/napari_yapic_prediction/napari.yaml
@@ -1,0 +1,10 @@
+name: napari-yapic-prediction
+schema_version: 0.1.0
+contributions:
+  commands:
+  - id: napari-yapic-prediction.MyWidget
+    title: Create My Widget
+    python_name: napari_yapic_prediction._dock_widget:MyWidget
+  widgets:
+  - command: napari-yapic-prediction.MyWidget
+    display_name: My Widget

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,9 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     ],
     entry_points={
-        'napari.plugin': [
-            'napari-yapic-prediction = napari_yapic_prediction',
+        "napari.manifest": [
+            "napari-yapic-prediction = napari_yapic_prediction:napari.yaml",
         ],
     },
+    package_data={"napari_yapic_prediction": ["napari.yaml"]},
 )


### PR DESCRIPTION
see: https://napari.org/stable/plugins/npe2_migration_guide.html